### PR TITLE
Add CustomTitle to the projects that are missing it

### DIFF
--- a/Call3rdPartyWebService/Call3rdPartyWebService.lvproject
+++ b/Call3rdPartyWebService/Call3rdPartyWebService.lvproject
@@ -387,7 +387,7 @@
 			<DataDepot />
 		</NameScopingEnvoy>
 	</Project>
-	<ProjectInformation Author="" ProjectIconFilename="Blank Project.png" xmlns="http://www.ni.com/PlatformFramework">
+	<ProjectInformation CustomTitle="Call 3rd Party Web Service"  Author="" ProjectIconFilename="Blank Project.png" xmlns="http://www.ni.com/PlatformFramework">
 		<p.Description>This example demonstrates how to use a WebVI to call the Earthquake API from the US Geological Survey and display recent earthquakes on a web page.</p.Description>
 	</ProjectInformation>
 </SourceFile>

--- a/CallLabVIEWWebService/WebVI/CallLabVIEWWebService.lvproject
+++ b/CallLabVIEWWebService/WebVI/CallLabVIEWWebService.lvproject
@@ -396,7 +396,7 @@
 			<DataDepot />
 		</NameScopingEnvoy>
 	</Project>
-	<ProjectInformation ProjectIconFilename="Blank Project.png" xmlns="http://www.ni.com/PlatformFramework">
+	<ProjectInformation CustomTitle="Call LabVIEW Web Service"  ProjectIconFilename="Blank Project.png" xmlns="http://www.ni.com/PlatformFramework">
 		<p.Description>This example demonstrates how to create a WebVI that makes requests to a LabVIEW web service, and how to create a LabVIEW 2016 web service that can respond to requests from a WebVI.</p.Description>
 	</ProjectInformation>
 </SourceFile>

--- a/CustomizeWithCss/CustomizeWithCss.lvproject
+++ b/CustomizeWithCss/CustomizeWithCss.lvproject
@@ -391,7 +391,7 @@
 			<DataDepot />
 		</NameScopingEnvoy>
 	</Project>
-	<ProjectInformation ProjectIconFilename="Blank Project.png" xmlns="http://www.ni.com/PlatformFramework">
+	<ProjectInformation CustomTitle="Customize With CSS" ProjectIconFilename="Blank Project.png" xmlns="http://www.ni.com/PlatformFramework">
 		<p.Description>This example demonstrates how to customize the HTML output of a WebVI using CSS.</p.Description>
 	</ProjectInformation>
 </SourceFile>

--- a/EmbedContentIntoWebVI/EmbedContentIntoWebVI.lvproject
+++ b/EmbedContentIntoWebVI/EmbedContentIntoWebVI.lvproject
@@ -383,7 +383,7 @@
 			<DataDepot />
 		</NameScopingEnvoy>
 	</Project>
-	<ProjectInformation Author="" ProjectIconFilename="Blank Project.png" xmlns="http://www.ni.com/PlatformFramework">
+	<ProjectInformation CustomTitle="Embed Content Into WebVI" Author="" ProjectIconFilename="Blank Project.png" xmlns="http://www.ni.com/PlatformFramework">
 		<p.Description>"This example demonstrates how to embed custom web content into the WebVI panel using LabVIEW NXG 2.0. "</p.Description>
 	</ProjectInformation>
 </SourceFile>

--- a/EmbedWebVIIntoContent/WebVI/EmbedWebVIIntoContent.lvproject
+++ b/EmbedWebVIIntoContent/WebVI/EmbedWebVIIntoContent.lvproject
@@ -377,7 +377,7 @@
 			<DataDepot />
 		</NameScopingEnvoy>
 	</Project>
-	<ProjectInformation Author="" ProjectIconFilename="Blank Project.png" xmlns="http://www.ni.com/PlatformFramework">
+	<ProjectInformation CustomTitle="Embed WebVI Into Content" Author="" ProjectIconFilename="Blank Project.png" xmlns="http://www.ni.com/PlatformFramework">
 		<p.Description>This example demonstrates how to embed the output of a WebVI built using LabVIEW NXG 2.0 into an static web page.</p.Description>
 	</ProjectInformation>
 </SourceFile>

--- a/IncorporateUserResources/IncorporateUserResources.lvproject
+++ b/IncorporateUserResources/IncorporateUserResources.lvproject
@@ -391,7 +391,7 @@
 			<DataDepot />
 		</NameScopingEnvoy>
 	</Project>
-	<ProjectInformation ProjectIconFilename="Blank Project.png" xmlns="http://www.ni.com/PlatformFramework">
+	<ProjectInformation CustomTitle="Incorporate User Resources" ProjectIconFilename="Blank Project.png" xmlns="http://www.ni.com/PlatformFramework">
 		<p.Description>This example demonstrates how to add resource files such as images, CSS files, JavaScript files, and HTML files to your Web application component</p.Description>
 	</ProjectInformation>
 </SourceFile>

--- a/MultipleTopLevelWebVIs/MultipleTopLevelWebVIs.lvproject
+++ b/MultipleTopLevelWebVIs/MultipleTopLevelWebVIs.lvproject
@@ -383,7 +383,7 @@
 			<DataDepot />
 		</NameScopingEnvoy>
 	</Project>
-	<ProjectInformation Author="" ProjectIconFilename="Blank Project.png" xmlns="http://www.ni.com/PlatformFramework">
+	<ProjectInformation CustomTitle="Multiple Top-Level WebVIs" Author="" ProjectIconFilename="Blank Project.png" xmlns="http://www.ni.com/PlatformFramework">
 		<p.Description>This example demonstrates how to create a web application with multiple pages by using multiple top-level WebVIs and Hyperlink controls to link between them.</p.Description>
 	</ProjectInformation>
 </SourceFile>


### PR DESCRIPTION
This fixes the title that is visible in the Examples lobby so that it has spaces. I will submit the same change to p4.