### PR TITLE
Fixing matching of regular expression with url of images in Call3rdPartyWebService.

### DIFF
--- a/Call3rdPartyWebService/WebApp.gcomp/support/Get Map URL.gviweb
+++ b/Call3rdPartyWebService/WebApp.gcomp/support/Get Map URL.gviweb
@@ -42,7 +42,7 @@
 		<FrontPanelUnplacedItems Id="11" Left="[float]0" MinHeight="[float]0" MinWidth="[float]0" PanelSizeMode="Fixed" Top="[float]0" />
 		<BlockDiagram Id="12">
 			<Literal Bounds="800 -95 505 15" DataType="String" Id="15" xmlns="http://www.ni.com/MocCommon">
-				<p.Data>https://earthquake.usgs.gov/realtime/product/losspager/%s/us/[0-9]+/exposure.png</p.Data>
+				<p.Data>https://earthquake.usgs.gov/archive/product/losspager/%s/us/[0-9]+/exposure.png</p.Data>
 				<StringBehavior TextDisplayMode="Default" />
 			</Literal>
 			<DataAccessor Bounds="1185 -65 40 15" DataItem="22" Id="23" Label="26" xmlns="http://www.ni.com/MocCommon">


### PR DESCRIPTION
Bug #1016607: https://dev.azure.com/ni/DevCentral/_workitems/edit/1016607
Changed part of the expression from 'realtime' to 'archive' since this is the convention the JSON reply from the server follows now. 

- - - - - - - -
- In **"Get Recent Earthquakes.gviweb"** there is a reference to the JSON call https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/significant_month.geojson

- Which, given as input in **"Get Earthquake Info.gviweb"** looks for ID **nn00725272**, corresponding to the image in index 0 and calls https://earthquake.usgs.gov/earthquakes/feed/v1.0/detail/nn00725272.geojson

- This, in turn, leads to image https://earthquake.usgs.gov/archive/product/losspager/nn00725272/us/1589542901052/exposure.png which is the one supposed to be shown.

- In contrast with the regular expression on **"Get Map URL.gviweb"** https://earthquake.usgs.gov/realtime/product/losspager/%s/us/[0-9]+/exposure.png it can be seen that the 'realtime' part of the expression is what is mismatching.

- However, the image https://earthquake.usgs.gov/archive/product/losspager/nn00725272/us/1589542901052/exposure.png does indeed exist. The problem is that it is not a part of the JSON reply, hence the regular expression is not finding it.
- - - - - - - -

Something interesting is that looking for https://earthquake.usgs.gov/archive/product/losspager/nn00725272 returns a **404 error**, while trying to access https://earthquake.usgs.gov/realtime/product/losspager/nn00725272 returns a message saying **403 Forbidden access error**. This made me think the server did indeed change their naming convention, and that there is not a valid 'realtime' version of the data out there. 

The JSON reply was monitored for some time and the data obtained from the server was being updated, further supporting this train of thought.